### PR TITLE
Update default package version to install to 1.8.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@
 
 default['openhab']['install_java']   = true
 default['openhab']['install_method'] = 'package'
-default['openhab']['version']        = '1.7.1'
+default['openhab']['version']        = '1.8.1'
 default['openhab']['plugins']        = []
 
 # Source only options:


### PR DESCRIPTION
For some reason I was never able to get 1.7.1 to install from the source repo @ bintray -- but 1.8.1 works just fine.  Tested with 'vagrant up' from a git clone.